### PR TITLE
fix: Refactor DICOM Tag Browser path check in Header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,6 +43,8 @@ const aboutModalCopyTooltips: [React.ReactNode, React.ReactNode] = [
   'Copied!',
 ]
 
+const DICOM_TAG_BROWSER_PATHS = ['/studies/', '/study/', '/projects/'] as const
+
 const aboutModalStyles: Record<string, React.CSSProperties> = {
   container: {
     textAlign: 'center',
@@ -398,7 +400,9 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       for (let i = 0; i < errorNum; i++) {
         const category = this.state.errorCategory[i] as ObjectKey
         errorMsgs[category].push(
-          `${this.state.errorObj[i].message as string} (Source: ${this.state.errorObj[i].source})`,
+          `${this.state.errorObj[i].message as string} (Source: ${
+            this.state.errorObj[i].source
+          })`,
         )
       }
     }
@@ -606,8 +610,9 @@ class Header extends React.Component<HeaderProps, HeaderState> {
       </Badge>
     )
 
-    const showDicomTagBrowser =
-      this.props.location.pathname.includes('/studies/')
+    const showDicomTagBrowser = DICOM_TAG_BROWSER_PATHS.some((path) =>
+      this.props.location.pathname.includes(path),
+    )
 
     const dicomTagBrowserButton = showDicomTagBrowser ? (
       <Button


### PR DESCRIPTION
- Replace repeated pathname.includes() calls with a single .some() over a shared path list
- Add module-level DICOM_TAG_BROWSER_PATHS constant for easier maintenance
- Avoid recreating the path array on each render